### PR TITLE
feat: run on ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   screenshots:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         theme: [light, dark, high-contrast-light, high-contrast-dark]
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
+          sudo apt install -y clang gsettings-desktop-schemas cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
           sudo apt install -y dbus-x11 fonts-ubuntu network-manager upower
           make install_deps
 


### PR DESCRIPTION
This should fix the recent CI failures caused by upgrading subiquity in `ubuntu-desktop-provision` (we need to run it on ubuntu 24.04 now, since it requires python 3.12)